### PR TITLE
Holding global variables staticly. 

### DIFF
--- a/inc/globals.h
+++ b/inc/globals.h
@@ -19,28 +19,26 @@
 
 /* Global input parameters */
 /* Points to master password */
-extern char *masterPwd;
+extern char masterPwd[];
 /* Points to account name */
-extern char *account;
+extern char account[];
 /* Points to domain name */
-extern char *domain;
+extern char domain[];
 /* Points to version */
-extern char *version;
+extern char version[];
 /* Points to cache (generated from master password in costly manner) */
-extern uint8_t *cache;
+extern uint8_t cache[];
 /* Length of generated password */
 extern unsigned pwdLen;
 
 /* Points to string representation of generated password */
-extern char *password;
+extern char password[];
 /* Toggles debug features of the program */
 extern int debug;
 
 /* Prevent interpositioning */
-#define initParams() pwdgenInitParams()
 #define eraseParams() pwdgenEraseParams()
 
-void initParams();
 void eraseParams();
 
 #endif

--- a/src/globals.c
+++ b/src/globals.c
@@ -4,42 +4,17 @@
 
 #include <globals.h>
 
-char *masterPwd;
-char *account;
-char *domain;
-char *version;
-char *password;
-uint8_t *cache;
+char masterPwd[257];
+char account[257];
+char domain[257];
+char version[17];
+char password[257];
+uint8_t cache[32];
 unsigned pwdLen;
 int debug;
 
 /**
- * Allocates the global input parameters and zeroises them.
- * XXX: Caller must free allocated memory.
- */
-void initParams()
-{
-    masterPwd = calloc(257, sizeof *masterPwd);
-    account = calloc(257, sizeof *account);
-    domain = calloc(257, sizeof *domain);
-    version = calloc(17, sizeof *version);
-    password = calloc(257, sizeof *password);
-    cache = calloc(32, sizeof *cache);
-
-    if (masterPwd == NULL || account == NULL || domain == NULL ||
-        version == NULL || password == NULL || cache == NULL)
-    {
-        fprintf(stderr, "Allocation error! Exiting...\n");
-        exit(EXIT_FAILURE);
-    }
-
-    pwdLen = 0;
-    debug = 0;
-}
-
-/**
- * Zeroises and deallocates the global input parameters,
- * as well as makes them point to NULL.
+ * Zeroises the global input parameters.
  */
 void eraseParams()
 {
@@ -50,18 +25,6 @@ void eraseParams()
     memset(password, 0, 257);
     memset(cache, 0, 32);
 
-    free(masterPwd);
-    free(account);
-    free(domain);
-    free(version);
-    free(password);
-    free(cache);
-
-    masterPwd = NULL;
-    account = NULL;
-    domain = NULL;
-    version = NULL;
-    password = NULL;
-    cache = NULL;
     pwdLen = 0;
+    debug = 0;
 }

--- a/src/ioCLI.c
+++ b/src/ioCLI.c
@@ -313,7 +313,7 @@ static inline int invalidNatNum(char const *kStr)
  */
 static void flush()
 {
-    char ch;
+    int ch;
 
     do
     {

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 
 int main(int argc, char *argv[])
 {
-    initParams();
+    eraseParams();
 
 #ifndef USE_ARGV_ONLY
     if (argc >= 2 && STRCMP(argv[1], ==, "-d"))


### PR DESCRIPTION
The global variables, defined in inc/globals.h, are now stored staticly. This removes the need of dynamically allocating and freeing them, so less can go wrong at runtime.

PS: steht auch genauso in der letzten commit message